### PR TITLE
ref change from gin-gonic/gin to halflife/gin

### DIFF
--- a/gin.go
+++ b/gin.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/gin-gonic/gin/render"
+	"github.com/halflife/gin/render"
 )
 
 // Framework's version

--- a/mode.go
+++ b/mode.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/gin-gonic/gin/binding"
+	"github.com/halflife/gin/binding"
 	"github.com/mattn/go-colorable"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-const BindKey = "_gin-gonic/gin/bindkey"
+const BindKey = "_halflife/gin/bindkey"
 
 func Bind(val interface{}) HandlerFunc {
 	value := reflect.ValueOf(val)


### PR DESCRIPTION
unable to compile without ref changes. most likely will revert this prior to pushing upstream.
